### PR TITLE
support options hash for keyUp, keyDown, and keyPress

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## 2.1.4
+
+- Add support for options hash to keyUp, keyPress, and keyDown DOMHelpers
+
 ## 2.1.3
 
 - Track `react` and `react-dom` as peer dependencies instead of dependencies.

--- a/lib/DOMHelpers.js
+++ b/lib/DOMHelpers.js
@@ -154,11 +154,32 @@ exports.submit = function(selector) {
  *
  * @param {String|HTMLElement} selector
  * @param {Number} keyCode
+ * @param {Object} options
  */
-exports.keyDown = function(selector, keyCode) {
+exports.keyDown = function(selector, keyCode, options = {}) {
   var node = find(selector, { assert: true, action: "keyDown" });
   node.focus();
-  Simulate.keyDown(node, { keyCode: keyCode, key: keyCode, which: keyCode });
+  Simulate.keyDown(node, {
+    keyCode: keyCode,
+    key: keyCode,
+    which: keyCode,
+    ctrlKey: options.ctrlKey === true,
+    altKey: options.altKey === true,
+    metaKey: options.metaKey === true,
+    shiftKey: options.shiftKey === true,
+    getModifierState(state) {
+      switch (state) {
+        case 'Alt':
+          return options.altKey === true;
+        case 'Shift':
+          return options.shiftKey === true;
+        case 'Meta':
+          return options.metaKey === true;
+        case 'Control':
+          return options.ctrlKey === true;
+      }
+    }
+  });
 };
 
 /**
@@ -166,11 +187,32 @@ exports.keyDown = function(selector, keyCode) {
  *
  * @param {String|HTMLElement} selector
  * @param {Number} keyCode
+ * @param {Object} options
  */
-exports.keyUp = function(selector, keyCode) {
+exports.keyUp = function(selector, keyCode, options = {}) {
   var node = find(selector, { assert: true, action: "keyUp" });
   node.focus();
-  Simulate.keyUp(node, { keyCode: keyCode, key: keyCode, which: keyCode });
+  Simulate.keyUp(node, {
+    keyCode: keyCode,
+    key: keyCode,
+    which: keyCode,
+    ctrlKey: options.ctrlKey === true,
+    altKey: options.altKey === true,
+    metaKey: options.metaKey === true,
+    shiftKey: options.shiftKey === true,
+    getModifierState(state) {
+      switch (state) {
+        case 'Alt':
+          return options.altKey === true;
+        case 'Shift':
+          return options.shiftKey === true;
+        case 'Meta':
+          return options.metaKey === true;
+        case 'Control':
+          return options.ctrlKey === true;
+      }
+    }
+  });
 };
 
 /**
@@ -178,11 +220,32 @@ exports.keyUp = function(selector, keyCode) {
  *
  * @param {String|HTMLElement} selector
  * @param {Number} keyCode
+ * @param {Object} options
  */
-exports.keyPress = function(selector, keyCode) {
+exports.keyPress = function(selector, keyCode, options = {}) {
   var node = find(selector, { assert: true, action: "keyPress" });
   node.focus();
-  Simulate.keyPress(node, { keyCode: keyCode, key: keyCode, which: keyCode });
+  Simulate.keyPress(node, {
+    keyCode: keyCode,
+    key: keyCode,
+    which: keyCode,
+    ctrlKey: options.ctrlKey === true,
+    altKey: options.altKey === true,
+    metaKey: options.metaKey === true,
+    shiftKey: options.shiftKey === true,
+    getModifierState(state) {
+      switch (state) {
+        case 'Alt':
+          return options.altKey === true;
+        case 'Shift':
+          return options.shiftKey === true;
+        case 'Meta':
+          return options.metaKey === true;
+        case 'Control':
+          return options.ctrlKey === true;
+      }
+    }
+  });
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-drill",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "React DOM test utils.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This commit modifies keyUp, keyDown, and keyPress to accept an options
hash. This allows you to pass modifiers (ctrlKey, metaKey, shiftKey, and
altKey) into an event.
