### PR TITLE
update react to 15.5.4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## 2.3.0
+- Now works with React 15.5.4
+- Removed explicit dependency on the `react-addons-test-utils` package since it's now in 'react-dom'
+
 ## 2.2.1
 
 - Fixed `#find` with HTMLElement or SVGElement in IE11

--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ npm install react-drill
 Browser build expects 3 things to be exposed on the global `window`:
 
 - [window.React](https://facebook.github.io/react/downloads.html)
-- [window.React.addons.TestUtils](https://facebook.github.io/react/docs/test-utils.html)
 - [window.jQuery](https://jquery.com/download/) _(this dependency may be dropped in the future)_
 
 ## Where to go from here

--- a/lib/DOM.js
+++ b/lib/DOM.js
@@ -1,5 +1,5 @@
 var ReactDOM = require('react-dom');
-var ReactTestUtils = require("react-addons-test-utils");
+var ReactTestUtils = require('react-dom/test-utils');
 
 exports.findDOMNode = ReactDOM.findDOMNode;
 exports.scryRenderedComponentsWithType = ReactTestUtils.scryRenderedComponentsWithType;

--- a/lib/DOMHelpers.js
+++ b/lib/DOMHelpers.js
@@ -1,5 +1,5 @@
 var $ = require("jquery");
-var ReactTestUtils = require("react-addons-test-utils");
+var ReactTestUtils = require('react-dom/test-utils');
 var Simulate = ReactTestUtils.Simulate;
 var SimulateNative = ReactTestUtils.SimulateNative;
 var DOMSelectors = require('./DOMSelectors');

--- a/package.json
+++ b/package.json
@@ -43,10 +43,9 @@
     "megadoc-theme-qt": "5.0.0",
     "mocha": "",
     "object-assign": "4.1.0",
-    "react": "15.4.1",
-    "react-addons-test-utils": "15.4.1",
+    "react": "15.5.4",
     "react-blessed": "0.x",
-    "react-dom": "15.4.1",
+    "react-dom": "15.5.4",
     "webpack": "^1.12.2"
   },
   "optionalDependencies": {},
@@ -57,7 +56,6 @@
   "dependencies": {
     "assertion-error": "^1.0.1",
     "invariant": "^2.2.2",
-    "jquery": "^3.1.1",
-    "react-addons-test-utils": "^15.4.1"
+    "jquery": "^3.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-drill",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "React DOM test utils.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
react 15.5 has moved ReactTestUtils to 'react-dom/test-utils' and
has a deprecation warning. So we update the react version and import
the new location